### PR TITLE
fix some errors happened when running CARLA

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -74,6 +74,7 @@ dependencies:
   - pillow=8.2.0=py38he98fc37_0
   - pip=21.0.1=py38h06a4308_0
   - pluggy=0.13.1=py38h06a4308_0
+  - psutil=5.8.0=py38h27cfd23_1
   - pwlf=2.0.4=py38h578d9bd_1
   - py=1.10.0=pyhd3eb1b0_0
   - pydoe=0.3.8=py_1


### PR DESCRIPTION
1. miss lib on psutil in `environment.yml`
2. sometimes the agent may be None, should add an if to judge

- [x] but there may cause the key missed?

```bash
[MainThread:igp2.carla.carla_cli] [DEBUG ]  CARLA step 336.
==========> warning this agent None
Traceback (most recent call last):
  File "scripts/experiments/carla_traffic_manager.py", line 126, in <module>
    main()
  File "scripts/experiments/carla_traffic_manager.py", line 120, in main
    visualiser.run(config["max_iter"])
  File "/home/kin/workspace/GITHUB/IGP2/igp2/carla/visualisation.py", line 1090, in run
    done = self._step(clock, world, display, controller)
  File "/home/kin/workspace/GITHUB/IGP2/igp2/carla/visualisation.py", line 1114, in _step
    world.tick(clock)
  File "/home/kin/workspace/GITHUB/IGP2/igp2/carla/visualisation.py", line 210, in tick
    self.igp2_hud.tick(self, clock)
  File "/home/kin/workspace/GITHUB/IGP2/igp2/carla/visualisation.py", line 582, in tick
    predictions = world.ego.agent.goal_probabilities[agent_id]
KeyError: 397
```

fix on commit: 5e942153cd62fd3a6420359f9e160cb88c0d1026 with adding id judge 